### PR TITLE
Update obsolete repository

### DIFF
--- a/kubernetes-dashboard/Setup-Dashboard.ps1
+++ b/kubernetes-dashboard/Setup-Dashboard.ps1
@@ -276,7 +276,7 @@ function Execute-Command
 
 
 $global:dashboardSecret      = "cluster-admin-dashboard"
-$global:dashboardYaml        = "https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta8/aio/deploy/recommended.yaml"
+$global:dashboardYaml        = "https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended.yaml"
 
 $global:dashboardPods =
 @(


### PR DESCRIPTION
Switching to _master_ since the beta (_v2.0.0-beta8_) dashboardYaml ("https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta8/aio/deploy/recommended.yaml") is no longer supported:

`Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead`